### PR TITLE
Support Reply-To and Sender header and name sanitization

### DIFF
--- a/lib/mailer.dart
+++ b/lib/mailer.dart
@@ -8,6 +8,7 @@ import 'package:intl/intl.dart';
 import 'package:path/path.dart';
 import 'package:mime/mime.dart';
 import 'package:logging/logging.dart';
+import 'package:charcode/ascii.dart';
 
 import 'src/util.dart';
 

--- a/lib/src/address.dart
+++ b/lib/src/address.dart
@@ -70,7 +70,7 @@ class AddressNotGroup extends AddressException {
 class Address {
   // Members
 
-  String _tmp; // internal use during parsing
+  StringBuffer _tmp; // internal use during parsing
   int _offset; // position reached when using the _parseMailbox constructor.
 
   //--------
@@ -312,7 +312,7 @@ class Address {
       var word = _tmp;
 
       if (word != null) {
-        words.add(word);
+        words.add(word.toString());
       } else {
         if (prevPos != null && prevPos == pos) {
           // Not the first time through, but there were no more words parsed
@@ -396,7 +396,7 @@ class Address {
             throw new AddressInvalid(
                 "local-part has unexpected final full-stop");
           }
-          words.add(word);
+          words.add(word.toString());
           break;
 
         case "@":
@@ -465,7 +465,7 @@ class Address {
       throw new AddressInvalid("addr-spec does not start with a word");
     }
 
-    pos = _parseAddrSpec(str, pos, end, [word]);
+    pos = _parseAddrSpec(str, pos, end, [word.toString()]);
 
     // The ">" terminating the route-addr
 
@@ -629,7 +629,7 @@ class Address {
           throw new AddressInvalid("domain has unexpected extra full-stop");
         }
       }
-      domain += _tmp;
+      domain += _tmp.toString();
       pos = subdomainEnd;
 
       pos = _skipCFWS(str, pos, end);
@@ -663,22 +663,22 @@ class Address {
     var n = begin + 1;
     while (n < end) {
       var ch = str.codeUnitAt(n);
-      if (ch == "\\".codeUnitAt(0)) {
+      if (ch == $backslash) {
         // Quoted pair
         n++;
         if (end < n) {
           throw new AddressInvalid("domain-literal not terminated");
         }
-        _tmp += str.substring(n, n + 1);
+        _tmp.writeCharCode(str.codeUnitAt(n));
         n++;
       } else if (33 <= ch &&
-          ch <= 126 &&
-          "\\[]\n".indexOf(new String.fromCharCode(ch)) < 0) {
+          ch <= 126 && (ch != $backslash && ch != $lbracket &&
+            ch != $rbracket && ch != $lf)) {
         // Valid character for an dtext
-        _tmp += str.substring(n, n + 1);
+        _tmp.writeCharCode(ch);
         n++;
-      } else if (ch != "]".codeUnitAt(0)) {
-        _tmp = str.substring(begin, n);
+      } else if (ch != $rbracket) {
+        _tmp = new StringBuffer(str.substring(begin, n));
         return n;
       } else {
         throw new AddressInvalid("domain-literal not terminated with \"]\"");
@@ -698,32 +698,33 @@ class Address {
 
     var nestingDepth = 0;
 
-    _tmp = "";
+    _tmp = new StringBuffer();
     var n = begin;
     while (n < end) {
-      switch (str.substring(n, n + 1)) {
-        case "(":
+      final ch = str.codeUnitAt(n);
+      switch (ch) {
+        case $lparen:
           // Start of a comment
           nestingDepth++;
           break;
-        case ")":
+        case $rparen:
           // End of a comment
           nestingDepth--;
           if (nestingDepth == 0) {
             return n + 1;
           }
           break;
-        case "\\":
+        case $backslash:
           // Escaped character
           if (str.length < n) {
             throw new AddressInvalid("Unterminated comment");
           }
-          _tmp += str.substring(n + 1, n + 2);
+          _tmp.writeCharCode(str.codeUnitAt(n + 1));
           n++;
           break;
         default:
           // Normal character
-          _tmp += str.substring(n, n + 1);
+          _tmp.writeCharCode(ch);
           break;
       }
       n++;
@@ -777,13 +778,13 @@ class Address {
 
     var n = begin;
     while (n < end) {
-      if (!_isAtomChar(str, n)) {
+      if (!_isAtomChar(str.codeUnitAt(n))) {
         break; // terminated by non-word character
       }
       n++;
     }
     if (begin < n) {
-      _tmp = str.substring(begin, n);
+      _tmp = new StringBuffer(str.substring(begin, n));
     } else {
       _tmp = null; // no word found
     }
@@ -798,25 +799,26 @@ class Address {
 
     // quoted-string = [CFWS]  DQUOTE *([FWS] qcontent) [FWS] DQUOTE [CFWS]
 
-    _tmp = "";
+    _tmp = new StringBuffer();
     var n = begin + 1;
     while (n < end) {
-      switch (str.substring(n, n + 1)) {
-        case "\"":
+      final ch = str.codeUnitAt(n);
+      switch (ch) {
+        case $double_quote:
           // End quote
           return _skipCFWS(str, n + 1, end);
 
-        case "\\":
+        case $backslash:
           // Escaped character
           if (str.length < n) {
             throw new AddressInvalid("Incomplete escape in quoted string");
           }
-          _tmp += str.substring(n + 1, n + 2);
+          _tmp.writeCharCode(str.codeUnitAt(n + 1));
           n++;
           break;
         default:
           // Normal character
-          _tmp += str.substring(n, n + 1);
+          _tmp.writeCharCode(ch);
           break;
       }
       n++;
@@ -831,11 +833,10 @@ class Address {
     var pos = begin;
 
     while (pos < end) {
-      var ch = str.substring(pos, pos + 1);
-
-      if (ch == " " || ch == "\t") {
+      var ch = str.codeUnitAt(pos);
+      if (ch == $space || ch == $tab) {
         pos++;
-      } else if (ch == "(") {
+      } else if (ch == $lparen) {
         pos = _parseComment(str, pos, end);
       } else {
         break;
@@ -848,20 +849,15 @@ class Address {
   //----------------------------------------------------------------
   /// Tests if character at position [pos] in the [str] can appear in an atom.
 
-  static bool _isAtomChar(String str, int pos) {
+  static bool _isAtomChar(int ch) {
     // A character from the "atext" production in RFC #5822.
-
-    var ch = str.codeUnitAt(pos);
-    if ("a".codeUnitAt(0) <= ch && ch <= "z".codeUnitAt(0) ||
-        "A".codeUnitAt(0) <= ch && ch <= "Z".codeUnitAt(0) ||
-        "0".codeUnitAt(0) <= ch && ch <= "9".codeUnitAt(0) ||
-        "!#\$%&'*+-/=?^_`{|}~".indexOf(new String.fromCharCode(ch)) >= 0 ||
-        127 < ch) {
-      return true;
-    } else {
-      return false;
-    }
+    return ($a <= ch && ch <= $z) ||
+        ($A <= ch && ch <= $Z) ||
+        ($0 <= ch && ch <= $9) ||
+        _atomCharCodes.contains(ch) ||
+        127 < ch;
   }
+  static final Set<int> _atomCharCodes = "!#\$%&'*+-/=?^_`{|}~".codeUnits.toSet();
 
   //----------------------------------------------------------------
   /// Returns the simple-address in a mailbox address.
@@ -954,25 +950,19 @@ class Address {
   static String _formatAtomOrQuotedString(String str) {
     // Check if string contains characters that need to be quoted
 
-    var needsQuoting = false;
-
     // It also needs quoting if it starts or ends with whitespace
     // or contains multiple whitespaces in sequence
 
-    if (str.length == 0) {
-      needsQuoting = true; // empty
-    } else if (str.substring(0, 1) == " " || str.substring(0, 1) == "\t") {
-      needsQuoting = true; // starts with whitespace
-    } else if (str.substring(str.length - 1, str.length) == " " ||
-        str.substring(str.length - 1, str.length) == "\t") {
-      needsQuoting = true; // ends with whitespace
-    }
+    var ch;
+    var needsQuoting = str.isEmpty
+       || (ch = str.codeUnitAt(0)) == $space || ch == $tab // starts with whitespace
+       || (ch = str.codeUnitAt(str.length - 1)) == $space || ch == $tab; // ends with whitespace
 
     var prevCharWasWhitespace = false;
     for (int n = 0; n < str.length; n++) {
-      var ch = str.substring(n, n + 1);
-      var isWhiteSpace = ch == ' ' || ch == "\t";
-      if (!_isAtomChar(str, n) && ! isWhiteSpace) {
+      var ch = str.codeUnitAt(n);
+      var isWhiteSpace = ch == $space || ch == $tab;
+      if (!_isAtomChar(ch) && !isWhiteSpace) {
         needsQuoting = true;
         break;
       }
@@ -989,28 +979,25 @@ class Address {
 
     // Produce the localPart@domain
 
-    var result;
     if (!needsQuoting) {
       // atom
-      result = str;
+      return str;
     } else {
       // quoted-string
-      result = '"';
+      final result = new StringBuffer('"');
       for (int n = 0; n < str.length; n++) {
-        if (_isAtomChar(str, n)) {
-          result += str.substring(n, n + 1);
+        final ch = str.codeUnitAt(n);
+        if (_isAtomChar(ch)) {
+          result.writeCharCode(ch);
         } else {
-          var ch = str.substring(n, n + 1);
-          if (ch == '"' || ch == "\\" || ch == "\r") {
-            result += "\\${ch}";
-          } else {
-            result += str.substring(n, n + 1);
-          }
+          if (ch == $double_quote || ch == $backslash || ch == $cr)
+            result.write("\\");
+          result.writeCharCode(ch);
         }
       }
-      result += '"';
+      result.write('"');
+      return result.toString();
     }
-    return result;
   }
 
   //----------------------------------------------------------------

--- a/lib/src/envelope.dart
+++ b/lib/src/envelope.dart
@@ -41,8 +41,9 @@ class Envelope {
       if (from != null) {
         var fromData = Address.sanitize(from);
 
-        if (fromName != null) {
-          fromData = '$fromName <$fromData>';
+        final name = sanitizeName(fromName);
+        if (name != null) {
+          fromData = '$name <$fromData>';
         }
 
         buffer.write('From: $fromData\n');
@@ -51,8 +52,9 @@ class Envelope {
       if (replyTo != null) {
         var replyToData = Address.sanitize(replyTo);
 
-        if (replyToName != null) {
-          replyToData = '$replyToName <$replyToData>';
+        final name = sanitizeName(replyToName);
+        if (name != null) {
+          replyToData = '$name <$replyToData>';
         }
 
         buffer.write('Reply-To: $replyToData\n');
@@ -61,8 +63,9 @@ class Envelope {
       if (sender != null) {
         var senderData = Address.sanitize(sender);
 
-        if (senderName != null) {
-          senderData = '$senderName <$senderData>';
+        final name = sanitizeName(senderName);
+        if (name != null) {
+          senderData = '$name <$senderData>';
         }
 
         buffer.write('Sender: $senderData\n');

--- a/lib/src/envelope.dart
+++ b/lib/src/envelope.dart
@@ -12,6 +12,8 @@ class Envelope {
   List<Attachment> attachments = [];
   String from = 'anonymous@${Platform.localHostname}';
   String fromName;
+  String replyTo;
+  String replyToName;
   String subject;
   String text;
   String html;
@@ -39,6 +41,16 @@ class Envelope {
         }
 
         buffer.write('From: $fromData\n');
+      }
+
+      if (replyTo != null) {
+        var replyToData = _sanitizeEmail(replyTo);
+
+        if (replyToName != null) {
+          replyToData = '$replyToName <$replyToData>';
+        }
+
+        buffer.write('Reply-To: $replyToData\n');
       }
 
       if (recipients != null && recipients.length > 0) {

--- a/lib/src/envelope.dart
+++ b/lib/src/envelope.dart
@@ -14,6 +14,8 @@ class Envelope {
   String fromName;
   String replyTo;
   String replyToName;
+  String sender;
+  String senderName;
   String subject;
   String text;
   String html;
@@ -51,6 +53,16 @@ class Envelope {
         }
 
         buffer.write('Reply-To: $replyToData\n');
+      }
+
+      if (sender != null) {
+        var senderData = _sanitizeEmail(sender);
+
+        if (senderName != null) {
+          senderData = '$senderName <$senderData>';
+        }
+
+        buffer.write('Sender: $senderData\n');
       }
 
       if (recipients != null && recipients.length > 0) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -22,5 +22,16 @@ chunkEncodedBytes(String encoded) {
 String sanitizeField(String value) {
   if (value == null) return '';
 
-  return value.replaceAll(new RegExp('(\\r|\\n|\\t)+', caseSensitive: false), '');
+  return value.replaceAll(_reField, ' ');
 }
+final RegExp _reField = new RegExp('(\\r|\\n|\\t)+');
+
+/// Sanitizes a display name (of an email address).
+String sanitizeName(String name) {
+  if (name == null || (name = name.trim()).isEmpty)
+    return null;
+
+  return _reName.hasMatch(name) ? name:
+    '"' + name.replaceAll('"', "'") + '"';
+}
+final RegExp _reName = new RegExp(r"^[- a-zA-Z0-9!#$%&'*+/=?^_`{|}~]*$");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   crypto: '>=0.9.0 <3.0.0'
   path: '>=0.9.0 <2.0.0'
   intl: '>=0.9.0 <2.0.0'
+  charcode: any
+
 dev_dependencies:
   args: ^0.13.5
   test: ^0.12.4


### PR DESCRIPTION
Allow the user to specify replyTo and sender:

http://tools.ietf.org/html/rfc4021#section-2.1.3
http://tools.ietf.org/html/rfc4021#section-2.1.4

Also, follow [RFC 5322](https://tools.ietf.org/html/rfc5322#page-12) to sanitize the display name.
