### PR TITLE
There is no class CryptoUtils

### DIFF
--- a/lib/mailer.dart
+++ b/lib/mailer.dart
@@ -7,8 +7,8 @@ import 'dart:convert';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart';
 import 'package:mime/mime.dart';
-import 'package:crypto/crypto.dart';
 import 'package:logging/logging.dart';
+import 'package:cryptoutils/cryptoutils.dart';
 
 part 'src/envelope.dart';
 part 'src/transport.dart';

--- a/lib/src/envelope.dart
+++ b/lib/src/envelope.dart
@@ -94,7 +94,7 @@ class Envelope {
 
         return attachment.file.readAsBytes().then((bytes) {
           // Create a chunk'd (76 chars per line) base64 string.
-          var contents = CryptoUtils.bytesToBase64(bytes, addLineSeparator: true);
+          var contents = CryptoUtils.bytesToBase64(bytes, false, true);
 
           buffer.write('--$boundary\n');
           buffer.write('Content-Type: ${_getMimeType(attachment.file.path)}; name="$filename"\n');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   unittest: '>=0.9.0 <2.0.0'
   mime: '>=0.9.0 <2.0.0'
   logging: '>=0.9.0 <2.0.0'
-  crypto: '>=1.0.0 <2.0.0'
+  crypto: '>=0.9.0 <2.0.0'
   path: '>=0.9.0 <2.0.0'
   intl: '>=0.9.0 <2.0.0'
   cryptoutils: ^0.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   unittest: '>=0.9.0 <2.0.0'
   mime: '>=0.9.0 <2.0.0'
   logging: '>=0.9.0 <2.0.0'
-  crypto: '>=0.9.0 <2.0.0'
+  crypto: '>=1.0.0 <2.0.0'
   path: '>=0.9.0 <2.0.0'
   intl: '>=0.9.0 <2.0.0'
+  cryptoutils: ^0.2.1


### PR DESCRIPTION
With the current version of the packages, the Analyzer says that there is an error in smtp_client.dart because there is no CryptoUtils class
It looks like that class is no longer in crypto package. So I added the cryptoutils package in pubspec.yaml to fix that. 