### PR TITLE
feat: guard completer against completing twice

### DIFF
--- a/lib/src/smtp/smtp_client.dart
+++ b/lib/src/smtp/smtp_client.dart
@@ -103,6 +103,13 @@ class SmtpClient {
             completer.complete(mail);
           }
         }, onError: (e) {
+          if (completer.isCompleted) {
+            // There was an error, after we got a 2xx for our mail from the
+            // server.  We don't care if closing the connection... generated
+            // an error.
+            _logger.info('Error after mail was successfully sent: $e');
+            return;
+          }
           _close();
           timeout.cancel();
           completer.completeError('Failed to send an email: $e');


### PR DESCRIPTION
If there is an error _after_ we got a 2xx from the server (i.e. the mail
was successfully sent already) the library should simply ignore it.

We don't care if disconnecting or closing the connection was
problematic.

fixes #28 