### PR TITLE
Fix already completed error.

### DIFF
--- a/lib/src/smtp/smtp_client.dart
+++ b/lib/src/smtp/smtp_client.dart
@@ -110,7 +110,12 @@ class SmtpClient {
         }, onError: (e) {
           _close();
           timeout.cancel();
-          completer.completeError('Failed to send an email: $e');
+          if (!completer.isCompleted) {
+            completer.completeError('Failed to send an email: $e');
+            _logger.finest('Failed to send email', e);
+          } else {
+            _logger.finest('Failed after sending email', e);
+          }
         }, cancelOnError: true);
 
         return completer.future;


### PR DESCRIPTION
Some cases, after sending an error will occur after completer is done.
Prevent it from crashing if completer is done and just log.

This resolves #28 