### PR TITLE
mime header / dart2,dart3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.1
+* if a header value is `null` send empty string instead.
+* if mime library fails to identify content use `text/plain` and `application/octet-stream`  
+  as defaults.
+* mention mailer2 and mailer3 in README
+
 ## 2.1.0
 * provide smtp_servers in smtp_server.dart
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@
 
 Mailer supports file attachments and HTML emails.
 
+
+## mailer2 and mailer3
+
+`mailer2` and `mailer3` on pub.dart are forks of this project.
+
+`mailer` had some issues and we only recently (dart2 support) started
+to work on issues / PRs.
+
+Currently `mailer` should include all known bug-fixes and AFAIK there is
+no reason to use `mailer2` or `mailer3`.
+
+
 ## Dart2 support
 
 Support for dart2 has been added in version ^1.2.0  

--- a/lib/src/entities/attachment.dart
+++ b/lib/src/entities/attachment.dart
@@ -37,6 +37,11 @@ class FileAttachment extends Attachment {
   FileAttachment(this._file, {String contentType, String fileName}) {
     if (contentType == null) {
       this.contentType = mime.lookupMimeType(_file.path);
+    } else {
+      this.contentType = contentType;
+    }
+    if (this.contentType == null) {
+      this.contentType = 'application/octet-stream';
     }
     this.fileName = fileName ?? basename(_file.path);
   }
@@ -62,8 +67,13 @@ class StringAttachment extends Attachment {
 
   StringAttachment(this._data, {String contentType, String fileName}) {
     if (contentType == null) {
-      this.contentType = mime.lookupMimeType(fileName ?? 'unknown',
+      this.contentType = mime.lookupMimeType(fileName ?? 'abc.txt',
           headerBytes: convert.utf8.encode(_data));
+    } else {
+      this.contentType = contentType;
+    }
+    if (this.contentType == null) {
+      this.contentType = 'text/plain';
     }
     this.fileName = fileName;
   }

--- a/lib/src/smtp/internal_representation/ir_header.dart
+++ b/lib/src/smtp/internal_representation/ir_header.dart
@@ -8,7 +8,7 @@ abstract class _IRHeader extends _IROutput {
   static final int _b64Length = _b64prefix.length + _b64postfix.length;
 
   Stream<List<int>> _outValue(String value) => new Stream.fromIterable(
-      [_name, ': ', value, eol].map(convert.utf8.encode));
+      [_name, ': ', value ?? '', eol].map(convert.utf8.encode));
 
   // Outputs value encoded as base64.
   // Every chunk starts with ' ' and ends with eol.
@@ -58,7 +58,7 @@ class _IRHeaderText extends _IRHeader {
   Stream<List<int>> out(_IRMetaInformation irMetaInformation) {
     bool utf8Allowed = irMetaInformation.capabilities.smtpUtf8;
 
-    if (_value.length > maxLineLength ||
+    if ((_value?.length ?? 0) > maxLineLength ||
         !_isPrintableRegExp.hasMatch(_value) ||
         // Make sure that text which looks like an encoded text is encoded.
         _value.contains('=?') ||

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 2.1.0
+version: 2.1.1
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails


### PR DESCRIPTION
fixes #66 
fixes #62 

* if a header value is `null` send empty string instead.
* if mime library fails to identify content use `text/plain` and `application/octet-stream`
  as defaults.
* manually passed content-types are no longer ignored.