### PR TITLE
Timeout property and SmtpClient.checkCredentials()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages
 .packages
 *.iml
 .dart_tool
+/test/smtpserver.json

--- a/lib/mailer.dart
+++ b/lib/mailer.dart
@@ -8,7 +8,8 @@ import 'src/smtp/smtp_client.dart';
 export 'src/entities.dart';
 export 'legacy.dart';
 
-Future<List<SendReport>> send(Message message, SmtpServer smtpServer) {
+Future<List<SendReport>> send(Message message, SmtpServer smtpServer,
+                             {Duration timeout: const Duration(seconds: 10)}) {
   var client = new SmtpClient(smtpServer);
-  return client.send(message);
+  return client.send(message, timeout: timeout);
 }

--- a/lib/src/smtp/connection.dart
+++ b/lib/src/smtp/connection.dart
@@ -29,8 +29,9 @@ class Connection {
   final SmtpServer _server;
   Socket _socket;
   StreamQueue<String> _socketIn;
+  final Duration timeout;
 
-  Connection(this._server);
+  Connection(this._server, { this.timeout: const Duration(seconds: 60)});
 
   bool get isSecure => _socket != null && _socket is SecureSocket;
 
@@ -111,11 +112,11 @@ class Connection {
     // Secured connection was demanded by the user.
     if (_server.ssl) {
       _socket = await SecureSocket.connect(_server.host, _server.port,
-          onBadCertificate: (_) => _server.ignoreBadCertificate);
+          onBadCertificate: (_) => _server.ignoreBadCertificate, timeout: timeout);
     } else {
-      _socket = await Socket.connect(_server.host, _server.port);
+      _socket = await Socket.connect(_server.host, _server.port, timeout: timeout);
     }
-    _socket.timeout(const Duration(seconds: 60));
+    _socket.timeout(timeout);
 
     _setSocketIn();
   }

--- a/lib/src/smtp/smtp_client.dart
+++ b/lib/src/smtp/smtp_client.dart
@@ -89,6 +89,30 @@ class SmtpClient {
     }
   }
 
+  /// Convenience method for testing SmtpServer configuration.
+  ///
+  /// Throws following exceptions if the configuration is incorrect or there is
+  /// no internet connection:
+  /// [SmtpClientAuthenticationException],
+  /// [SmtpException],
+  /// [SocketException]
+  /// others
+  Future checkCredentials({Duration timeout: const Duration(seconds: 10)}) async {
+    final Connection c = new Connection(_smtpServer, timeout: timeout);
+
+    try {
+      await c.connect();
+      await c.send(null);
+      var capabilities = await _doEhloHelo(c);
+
+      c.verifySecuredConnection();
+      await _doAuthentication(c, capabilities);
+
+    } finally {
+      c.close();
+    }
+  }
+
   Future<List<SendReport>> send(Message message,
       {Duration timeout = const Duration(seconds: 60)}) async {
 

--- a/lib/src/smtp/smtp_client.dart
+++ b/lib/src/smtp/smtp_client.dart
@@ -14,16 +14,15 @@ import 'validator.dart';
 final Logger _logger = new Logger('smtp-client');
 
 class SmtpClient {
-  final Connection _c;
   final SmtpServer _smtpServer;
 
-  SmtpClient(this._smtpServer) : _c = new Connection(_smtpServer);
+  SmtpClient(this._smtpServer);
 
   /// Returns the capabilities of the server if ehlo was successful.  null if
   /// `helo` is necessary.
-  Future<Capabilities> _doEhlo() async {
+  Future<Capabilities> _doEhlo(Connection c) async {
     var respEhlo =
-        await _c.send('EHLO ${_smtpServer.name}', acceptedRespCodes: null);
+    await c.send('EHLO ${_smtpServer.name}', acceptedRespCodes: null);
 
     if (!respEhlo.responseCode.startsWith('2')) {
       return null;
@@ -31,39 +30,39 @@ class SmtpClient {
 
     var capabilities = new Capabilities.fromResponse(respEhlo.responseLines);
 
-    if (!capabilities.startTls || _c.isSecure) {
+    if (!capabilities.startTls || c.isSecure) {
       return capabilities;
     }
 
     // Use a secure socket.  Server announced STARTTLS.
     // The server supports TLS and we haven't switched to it yet,
     // so let's do it.
-    var tlsResp = await _c.send('STARTTLS', acceptedRespCodes: null);
+    var tlsResp = await c.send('STARTTLS', acceptedRespCodes: null);
     if (!tlsResp.responseCode.startsWith('2')) {
       // Even though server announced STARTTLS, it now chickens out.
       return null;
     }
 
     // Replace _socket with an encrypted version.
-    await _c.upgradeConnection();
+    await c.upgradeConnection();
 
     // Restart EHLO process.  This time on a secure connection.
-    return _doEhlo();
+    return _doEhlo(c);
   }
 
-  Future<Capabilities> _doEhloHelo() async {
-    var ehlo = await _doEhlo();
+  Future<Capabilities> _doEhloHelo(Connection c) async {
+    var ehlo = await _doEhlo(c);
 
     if (ehlo != null) {
       return ehlo;
     }
 
     // EHLO not accepted.  Let's try HELO.
-    await _c.send('HELO ${_smtpServer.name}');
+    await c.send('HELO ${_smtpServer.name}');
     return new Capabilities();
   }
 
-  Future<Null> _doAuthentication(Capabilities capabilities) async {
+  Future<Null> _doAuthentication(Connection c, Capabilities capabilities) async {
     if (_smtpServer.username == null) {
       return;
     }
@@ -77,12 +76,12 @@ class SmtpClient {
     var password = _smtpServer.password;
 
     // 'Username:' in base64 is: VXN...
-    await _c.send('AUTH LOGIN',
+    await c.send('AUTH LOGIN',
         acceptedRespCodes: ['334'], expect: 'VXNlcm5hbWU6');
     // 'Password:' in base64 is: UGF...
-    await _c.send(convert.base64.encode(username.codeUnits),
+    await c.send(convert.base64.encode(username.codeUnits),
         acceptedRespCodes: ['334'], expect: 'UGFzc3dvcmQ6');
-    var loginResp = await _c
+    var loginResp = await c
         .send(convert.base64.encode(password.codeUnits), acceptedRespCodes: []);
     if (!loginResp.responseCode.startsWith('2')) {
       throw new SmtpClientAuthenticationException(
@@ -90,8 +89,11 @@ class SmtpClient {
     }
   }
 
-  Future<List<SendReport>> send(Message message) async {
+  Future<List<SendReport>> send(Message message,
+      {Duration timeout = const Duration(seconds: 60)}) async {
+
     final List<SendReport> sendReports = [];
+    final Connection c = new Connection(_smtpServer, timeout: timeout);
 
     // Don't even try to connect to the server, if message-validation fails.
     var problems = validate(message);
@@ -112,18 +114,18 @@ class SmtpClient {
     }
 
     try {
-      await _c.connect();
+      await c.connect();
 
       // Greeting (Don't send anything.  We first wait for a 2xx message.)
-      await _c.send(null);
+      await c.send(null);
 
       // EHLO / HELO
-      var capabilities = await _doEhloHelo();
+      var capabilities = await _doEhloHelo(c);
 
-      _c.verifySecuredConnection();
+      c.verifySecuredConnection();
 
       // Authenticate
-      await _doAuthentication(capabilities);
+      await _doAuthentication(c, capabilities);
 
       Iterable<String> envelopeTos = irMessage.envelopeTos;
 
@@ -144,22 +146,24 @@ class SmtpClient {
       // 'From: ' header!)
 
       bool smtputf8 = capabilities.smtpUtf8;
-      await _c.send(
-          'MAIL FROM:<${irMessage.envelopeFrom}> ${smtputf8 ? ' SMTPUTF8' : ''}');
+      await c.send(
+          'MAIL FROM:<${irMessage.envelopeFrom}> ${smtputf8
+              ? ' SMTPUTF8'
+              : ''}');
 
       // Give the server all recipients.
       // TODO what if only one address fails?
       await Future.forEach(
-          envelopeTos, (recipient) => _c.send('RCPT TO:<$recipient>'));
+          envelopeTos, (recipient) => c.send('RCPT TO:<$recipient>'));
 
       // Finally send the actual mail.
-      await _c.send('DATA', acceptedRespCodes: ['2', '3']);
+      await c.send('DATA', acceptedRespCodes: ['2', '3']);
 
-      await _c.sendStream(irMessage.data(capabilities));
+      await c.sendStream(irMessage.data(capabilities));
 
-      await _c.send('.', acceptedRespCodes: ['2', '3']);
+      await c.send('.', acceptedRespCodes: ['2', '3']);
 
-      await _c.send('QUIT', waitForResponse: false);
+      await c.send('QUIT', waitForResponse: false);
 
       sendReports.add(new SendReport(message, true));
     } catch (exception) {
@@ -167,7 +171,7 @@ class SmtpClient {
         new Problem('UNKNOWN', 'Received an exception: $exception')
       ]));
     } finally {
-      await _c.close();
+      await c.close();
     }
 
     return sendReports;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,4 +20,5 @@ dependencies:
   dart2_constant: ^1.0.0
 dev_dependencies:
   args: ^1.5.0
+  test: ^1.5.1
 

--- a/test/send_test.dart
+++ b/test/send_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+import 'dart:async';
+
+import 'package:mailer/mailer.dart';
+import 'package:mailer/smtp_server.dart';
+import "package:test/test.dart";
+import 'dart:convert' as JSON;
+
+
+Future<SmtpServer> configureCorrectSmtpServer() async {
+  var config = File('test/smtpserver.json');
+  final json = JSON.jsonDecode(await config.readAsString());
+
+  return SmtpServer(
+    json['host'] as String,
+    username: json['username'] as String,
+    password: json['password'] as String,
+    port: json['port'] as int,
+    ssl: json['ssl'] as bool,
+    allowInsecure: json['allowInsecure'] as bool,
+  );
+}
+
+Message createMessage(SmtpServer smtpServer, int number) {
+  // Message to myself
+  return new Message()
+    ..from = new Address(smtpServer.username)
+    ..recipients.add(smtpServer.username)
+    ..subject = 'Test[$number] Dart Mailer library :: 😀 :: ${new DateTime.now()}'
+    ..text = 'This is the plain text.\nThis is line 2 of the text part.';
+}
+
+void main() async {
+  final SmtpServer correctSmtpServer = await configureCorrectSmtpServer();
+
+  test('Sending email', () async {
+
+    List<SendReport> reports = await send(createMessage(correctSmtpServer, 1),
+                                          correctSmtpServer,
+                                          timeout: Duration(seconds: 10));
+    expect(reports.last.sent, true);
+  });
+
+}


### PR DESCRIPTION
The default timeout duration 60s was too long for me.
I have added the timeout property to SmtpClient.send().

In this pull request the Connection object is created in SmtpClient.send() and the SmtpClient._c is removed.
Why? Suppose:
```
SmtpClient() // SmtpClient._c is created
SmtpClient.send() // SmtpClient._c connected and is waiting in the queue
SmtpClient.send() // SmtpClient._c.connect() called once again on the same instance 
```

With SmtpClient.checkeCredentials() you can check if SmtpServer configuration is correct, without sending an email.