### PR TITLE
feat: allow older pedantic version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+* allow older pedantic version to make mailer compatible with flutter.
+
 ## 3.0.0
 * NO BUGFIXES.  There is no *need* to update!
 * remove dart 1 compatible code.  mailer does require dart 2.2.2 or higer now.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 3.0.0
+version: 3.0.1
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails
@@ -19,7 +19,7 @@ dependencies:
   intl: '>0.9.0 <1.0.0'
   mime: '>0.9.0 <1.0.0'
   path: '>0.9.0 <2.0.0'
-  pedantic: '^1.7.0'
+  pedantic: '>=1.5.0 <2.0.0'
 
 dev_dependencies:
   args: '>=1.5.0 <2.0.0'


### PR DESCRIPTION
This should make `mailer` compatible with `flutter`.
Fixes #102