### PR TITLE
fix: file operations return an Uint8List instead of List<Int>

### DIFF
--- a/lib/src/smtp/connection.dart
+++ b/lib/src/smtp/connection.dart
@@ -133,9 +133,8 @@ class Connection {
     if (_socketIn != null) {
       _socketIn.cancel();
     }
-    _socketIn = new StreamQueue<String>(_socket
-        .transform(convert.utf8.decoder)
-        .transform(const LineSplitter()));
+    _socketIn = StreamQueue<String>(
+        convert.utf8.decoder.bind(_socket).transform(const LineSplitter()));
   }
 
   void verifySecuredConnection() {

--- a/lib/src/smtp/internal_representation/ir_content.dart
+++ b/lib/src/smtp/internal_representation/ir_content.dart
@@ -24,8 +24,8 @@ abstract class _IRContent extends _IROutput {
       Stream<List<int>> content, _IRMetaInformation irMetaInformation) async* {
     yield* _outH(irMetaInformation);
     yield eol8;
-    yield* content
-        .transform(convert.base64.encoder)
+    yield* convert.base64.encoder
+        .bind(content)
         .transform(convert.ascii.encoder)
         .transform(new StreamSplitter(splitOverLength, maxLineLength));
     yield eol8;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 2.5.1
+version: 2.6.0
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails
@@ -9,7 +9,7 @@ authors:
 - Matthew Butler <butler.matthew@gmail.com>
 - Christian Loitsch <christian@loitsch.com>
 - Piotr Kroll <piotr@kroll.eu>
-homepage: http://github.com/kaisellgren/mailer
+homepage: https://github.com/kaisellgren/mailer
 environment:
   sdk: '>=1.24.0 <3.0.0'
 dependencies:


### PR DESCRIPTION
This is the fix for [this breaking change in Flutter](https://groups.google.com/forum/#!topic/flutter-announce/LTe4SYU8-0Q), cherry picked from de1afb5fa16359268823874aec94f2f3686c20b2.

I need this because:

- I am on the Flutter beta channel (currently 1.8.3)
- I use [catcher](https://pub.dev/packages/catcher) 0.0.10, which depends on mailer 2.5.1
- mailer 3.0.2 is not compatible with catcher 0.0.10
- I can't update catcher because I can't upgrade to AndroidX for various reasons