### PR TITLE
fix: fix nullp exc. when server doesn't support EHLO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.4
+* fix null pointer when server doesn't support EHLO (#121)
+
 ## 3.0.3
 * fix splitting of text for base64 conversion.
 

--- a/lib/src/smtp/smtp_client.dart
+++ b/lib/src/smtp/smtp_client.dart
@@ -10,13 +10,12 @@ import 'connection.dart';
 import 'exceptions.dart';
 import 'internal_representation/internal_representation.dart';
 
-/// Returns the capabilities of the server if ehlo was successful.  null if
-/// `helo` is necessary.
+/// Returns if ehlo was successful.
 Future<bool> _doEhlo(Connection c, String clientName) async {
   var respEhlo = await c.send('EHLO $clientName', acceptedRespCodes: null);
 
   if (!respEhlo.responseCode.startsWith('2')) {
-    return null;
+    return false;
   }
 
   var capabilities = new Capabilities.fromResponse(respEhlo.responseLines);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 3.0.3
+version: 3.0.4
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails


### PR DESCRIPTION
bump version to 3.0.4

Mailer v2 used to return the capabilities when trying to perform an EHLO.  In case EHLO was unsuccessful `null` was returned.
Mailer v3 uses a member variable for the capabilities and returns a boolean.  I however forgot to change the return from `null` to `false` in case of an EHLO failure. 

fixes #121 