### PR TITLE
Fix #152: encoding name of addresses in utf-8

### DIFF
--- a/lib/src/entities/address.dart
+++ b/lib/src/entities/address.dart
@@ -1,8 +1,8 @@
 class Address {
-  String name;
-  String mailAddress;
+  final String name;
+  final String mailAddress;
 
-  Address([this.mailAddress, this.name]);
+  const Address([this.mailAddress, this.name]);
 
   /// Generates an address that must conform to RFC 5322.
   /// For example, `name <foo@domain.com>`, `<foo@domain.com>`

--- a/lib/src/entities/address.dart
+++ b/lib/src/entities/address.dart
@@ -4,13 +4,14 @@ class Address {
 
   const Address([this.mailAddress, this.name]);
 
-  /// Generates an address that must conform to RFC 5322.
-  /// For example, `name <foo@domain.com>`, `<foo@domain.com>`
-  /// and `foo.domain.com`.
+  /// The name used to output to SMTP server.
+  /// Implementation can override it to pre-process the name before sending.
+  /// For example, providing a default name for certain address, or quoting it.
+  String get sanitizedName => name;
+  /// The address used to output to SMTP server.
+  /// Implementation can override it to pre-process the address before sending
+  String get sanitizedAddress => mailAddress;
+
   @override
-  String toString() {
-    var fromName = name ?? '';
-    // ToDo base64 fromName (add _IRMetaInformation as argument)
-    return '$fromName <$mailAddress>';
-  }
+  String toString() => "${name ?? ''} <$mailAddress>";
 }

--- a/lib/src/smtp/internal_representation/ir_header.dart
+++ b/lib/src/smtp/internal_representation/ir_header.dart
@@ -3,17 +3,64 @@ part of 'internal_representation.dart';
 abstract class _IRHeader extends _IROutput {
   final String _name;
 
-  static final List<int> _b64prefix = convert.utf8.encode(' =?utf-8?B?');
-  static final List<int> _b64postfix = convert.utf8.encode('?=$eol');
+  static final _b64prefix = convert.utf8.encode('=?utf-8?B?'),
+    _b64postfix = convert.utf8.encode('?='),
+    _$eol = convert.utf8.encode(eol),
+    _$eolSpace = convert.utf8.encode('$eol '),
+    _$spaceLt = convert.utf8.encode(' <'),
+    _$gt = convert.utf8.encode('>'),
+    _$commaSpace = convert.utf8.encode(', '),
+    _$colonSpace = convert.utf8.encode(': ');
   static final int _b64Length = _b64prefix.length + _b64postfix.length;
 
-  Stream<List<int>> _outValue(String value) => Stream.fromIterable(
-      [_name, ': ', value ?? '', eol].map(convert.utf8.encode));
+  Stream<List<int>> _outValue(String value) async* {
+    yield convert.utf8.encode(_name);
+    yield _$colonSpace;
+    if (value != null) yield convert.utf8.encode(value);
+    yield _$eol;
+  }
 
-  // Outputs value encoded as base64.
+  // Outputs this header's name and the given [value] encoded as base64.
   // Every chunk starts with ' ' and ends with eol.
   // Call _outValueB64 after an eol.
   Stream<List<int>> _outValueB64(String value) async* {
+    assert(value != null);
+    yield convert.utf8.encode(_name);
+    yield _$colonSpace;
+    yield* _outB64(value);
+    yield _$eol;
+  }
+
+  /// Outputs the given [addresses].
+  Stream<List<int>> _outAddressesValue(Iterable<Address> addresses,
+      _IRMetaInformation irMetaInformation) async* {
+    yield convert.utf8.encode(_name);
+    yield _$colonSpace;
+
+    bool second = false;
+    for (final address in addresses) {
+      if (second) yield _$commaSpace;
+      else second = true;
+
+      final name = address.sanitizedName,
+        maddr = address.sanitizedAddress;
+      if (name == null) {
+        yield convert.utf8.encode(maddr);
+      } else {
+        if (_shallB64(name, irMetaInformation)) yield* _outB64(name);
+        else yield convert.utf8.encode(name);
+
+        yield _$spaceLt;
+        yield convert.utf8.encode(maddr);
+        yield _$gt;
+      }
+    }
+
+    yield _$eol;
+  }
+
+  // Outputs the given [value] encoded as base64.
+  static Stream<List<int>> _outB64(String value) async* {
     // Encode with base64.
     var availableLengthForBase64 = maxEncodedLength - _b64Length;
 
@@ -24,14 +71,24 @@ abstract class _IRHeader extends _IROutput {
     // At least 10 chars (random length).
     if (availableLength < 10) availableLength = 10;
 
-    var splitData = split(convert.utf8.encode(value), availableLength);
+    var second = false;
+    for (var d in split(convert.utf8.encode(value), availableLength)) {
+      if (second) yield _$eolSpace;
+      else second = true;
 
-    yield convert.utf8.encode('$_name: $eol');
-    for (var d in splitData) {
       yield _b64prefix;
       yield convert.utf8.encode(convert.base64.encode(d));
       yield _b64postfix;
     }
+  }
+
+  static bool _shallB64(String value, _IRMetaInformation irMetaInformation) {
+    return value != null && (value.length > maxLineLength ||
+        !isPrintableRegExp.hasMatch(value) ||
+        // Make sure that text which looks like an encoded text is encoded.
+        value.contains('=?') ||
+        (!irMetaInformation.capabilities.smtpUtf8 &&
+            value.contains(RegExp(r'[^\x20-\x7E]'))));
   }
 
   /*
@@ -48,22 +105,10 @@ class _IRHeaderText extends _IRHeader {
   _IRHeaderText(String name, this._value) : super(name);
 
   @override
-  Stream<List<int>> out(_IRMetaInformation irMetaInformation) {
-    bool utf8Allowed = irMetaInformation.capabilities.smtpUtf8;
-
-    if ((_value?.length ?? 0) > maxLineLength ||
-        !isPrintableRegExp.hasMatch(_value) ||
-        // Make sure that text which looks like an encoded text is encoded.
-        _value.contains('=?') ||
-        (!utf8Allowed && _value.contains(RegExp(r'[^\x20-\x7E]')))) {
-      return _outValueB64(_value);
-    }
-    return _outValue(_value);
-  }
+  Stream<List<int>> out(_IRMetaInformation irMetaInformation)
+  => _IRHeader._shallB64(_value, irMetaInformation) ?
+      _outValueB64(_value): _outValue(_value);
 }
-
-Iterable<String> _addressToString(Iterable<Address> addresses)
-=> addresses == null ? []: addresses.map((a) => a.toString());
 
 class _IRHeaderAddress extends _IRHeader {
   Address _address;
@@ -72,7 +117,7 @@ class _IRHeaderAddress extends _IRHeader {
 
   @override
   Stream<List<int>> out(_IRMetaInformation irMetaInformation) =>
-      _outValue(_addressToString([_address]).first);
+      _outAddressesValue([_address], irMetaInformation);
 }
 
 class _IRHeaderAddresses extends _IRHeader {
@@ -82,7 +127,7 @@ class _IRHeaderAddresses extends _IRHeader {
 
   @override
   Stream<List<int>> out(_IRMetaInformation irMetaInformation) =>
-      _outValue(_addressToString(_addresses).join(', '));
+      _outAddressesValue(_addresses, irMetaInformation);
 }
 
 class _IRHeaderContentType extends _IRHeader {

--- a/lib/src/smtp/internal_representation/ir_header.dart
+++ b/lib/src/smtp/internal_representation/ir_header.dart
@@ -37,13 +37,23 @@ abstract class _IRHeader extends _IROutput {
     yield convert.utf8.encode(_name);
     yield _$colonSpace;
 
-    bool second = false;
+    var len = 2, //2 = _$commaSpace
+      second = false;
     for (final address in addresses) {
-      if (second) yield _$commaSpace;
-      else second = true;
-
       final name = address.sanitizedName,
         maddr = address.sanitizedAddress;
+      var adrlen = maddr.length;
+      if (name != null) adrlen += name.length + 3; //not accurate but good enough
+
+      if (second) {
+        yield _$commaSpace;
+
+        if (len + adrlen > maxEncodedLength) {
+          len = 2;
+          yield _$eolSpace;
+        }
+      } else second = true;
+
       if (name == null) {
         yield convert.utf8.encode(maddr);
       } else {
@@ -54,6 +64,8 @@ abstract class _IRHeader extends _IROutput {
         yield convert.utf8.encode(maddr);
         yield _$gt;
       }
+
+      len += adrlen;
     }
 
     yield _$eol;

--- a/lib/src/smtp/validator.dart
+++ b/lib/src/smtp/validator.dart
@@ -15,9 +15,8 @@ bool _validAddress(dynamic addressIn) {
 
   String address;
   if (addressIn is Address) {
-    //We can't validate [Address.name] directly, since the implementation
-    //of [Address.toString] might sanitize it.
-    if (!_printableCharsOnly(addressIn.toString())) return false;
+    //Don't validate [Address.name] here since it will be encoded with base64
+    //if necessary
     address = addressIn.mailAddress;
   } else {
     address = addressIn as String;


### PR DESCRIPTION
@close2 I fixed #152 by encoding name to utf-8+base64.

Note:

1. It doesn't support 2.12 yet
1. I introduced `Address.sanitizedName` and `sanitizedAddress` for application to override (which I need it).
1. I made `Address`'s `name` and `mailAddress` as final, so `const Address` is possible.
   * I know you revoked it when merging the code. But, I think the version of 2.12 is a good opportunity to drop some backward compatible code.
   * Make them final have two advantages: 1) easy to override, 2) able to use `const` to make the code a bit more efficient.

Item 2 and 3 are not necessary. If you don't like it you can revoke it.