### PR TITLE
Fix Null error when closing smtp connection.

### DIFF
--- a/lib/src/smtp/mail_sender.dart
+++ b/lib/src/smtp/mail_sender.dart
@@ -14,7 +14,8 @@ final Logger _logger = Logger('mailer_sender');
 class _MailSendTask {
   // If [message] is `null` close connection.
   Message? message;
-  late Completer<SendReport> completer;
+  // if `null` connection close was successful.
+  late Completer<SendReport?> completer;
 }
 
 class PersistentConnection {
@@ -58,7 +59,9 @@ class PersistentConnection {
       ..message = message
       ..completer = Completer();
     mailSendTasksController.add(mailTask);
-    return mailTask.completer.future;
+    return mailTask.completer.future
+        // `null` is only a valid return value for connection close messages.
+        .then((value) => ArgumentError.checkNotNull(value));
   }
 
   /// Throws following exceptions:
@@ -102,7 +105,8 @@ Future<SendReport> send(Message message, SmtpServer smtpServer,
 /// [SmtpClientCommunicationException],
 /// [SocketException]
 /// others
-Future<void> checkCredentials(SmtpServer smtpServer, {Duration? timeout}) async {
+Future<void> checkCredentials(SmtpServer smtpServer,
+    {Duration? timeout}) async {
   var connection = await client.connect(smtpServer, timeout);
   await client.close(connection);
 }


### PR DESCRIPTION
When closing a connection gracefully `null` is put into a `Completer` which is non-nullable. (seams to be the same as #186)

```
2021-08-09 14:48:12.444144 SEVERE smtpd_healthcheck_command - Error during smtp.
### _TypeError: type 'Null' is not a subtype of type 'FutureOr<SendReport>'
#0      _AsyncCompleter.complete (dart:async/future_impl.dart:46)
#1      new PersistentConnection.<anonymous closure> (package:mailer/src/smtp/mail_sender.dart:35)
<asynchronous suspension>
```
