### PR TITLE
fix: specify locale in date header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+* Specify locale for date headers
+  Thanks https://github.com/michael-spf for the bug report
+
 ## 5.1.0
 * Include the SMTP error code in the authentication failure exception
   Thanks: https://github.com/jonasfj

--- a/lib/src/smtp/internal_representation/ir_header.dart
+++ b/lib/src/smtp/internal_representation/ir_header.dart
@@ -173,7 +173,7 @@ class _IRHeaderDate extends _IRHeader {
   final DateTime _dateTime;
 
   static final DateFormat _dateFormat =
-      DateFormat('EEE, dd MMM yyyy HH:mm:ss +0000');
+      DateFormat('EEE, dd MMM yyyy HH:mm:ss +0000', 'en_US');
 
   _IRHeaderDate(String name, this._dateTime) : super(name);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 5.1.0
+version: 5.1.1
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails

--- a/test/messages/message_helpers.dart
+++ b/test/messages/message_helpers.dart
@@ -2,7 +2,7 @@ part of message_out_test;
 
 String e(String stringToEscape) => RegExp.escape(stringToEscape);
 
-const dateHeader =
+const defaultDateHeader =
     'date: [\\w]{3}, [0-9]+ [\\w]{3} 2[0-9]{3} [0-9]{1,2}:[0-9]{2}:[0-9]{2} \\+[0-9]{4}\r\n';
 const contentTypeHeaderAlternative =
     'content-type: multipart/alternative;boundary="mailer-\\?=(?<boundaryAlternative>.*)"\r\n';
@@ -29,12 +29,16 @@ final defaultText = 'utf8😀t';
 final defaultHtml = 'utf8😀h';
 
 String mailRegExpTextAndHtml(String subject,
-    {String? text, String? html, String? fromHeader}) {
-  return '^'
-          'subject: $subject\r\n'
+    {String? text, String? html, String? fromHeader, String? dateHeader}) {
+  return '^' +
+      (dateHeader ??
+          '') + // if the date header is specified it comes before the subject.
+      'subject: $subject\r\n'
           'from: ${fromHeader ?? defaultFromRegExp}\r\n' +
       e('to: test2@test.com\r\n') +
-      dateHeader +
+      (dateHeader != null
+          ? ''
+          : defaultDateHeader) + // if not the date header comes after the to header
       e('x-mailer: Dart Mailer library\r\n') +
       e('mime-version: 1.0\r\n') +
       contentTypeHeaderAlternative +
@@ -72,7 +76,7 @@ String mailRegExpTextHtmlAndInlineAttachments(String subject,
           'subject: $subject\r\n'
           'from: ${fromHeader ?? defaultFromRegExp}\r\n' +
       e('to: test2@test.com\r\n') +
-      dateHeader +
+      defaultDateHeader +
       e('x-mailer: Dart Mailer library\r\n') +
       e('mime-version: 1.0\r\n') +
       contentTypeHeaderMixed +
@@ -126,7 +130,7 @@ String mailRegExpTextOrHtml(String subject,
           'subject: $subject\r\n'
           'from: ${fromHeader ?? defaultFromRegExp}\r\n' +
       e('to: test2@test.com\r\n') +
-      dateHeader +
+      defaultDateHeader +
       e('x-mailer: Dart Mailer library\r\n') +
       e('mime-version: 1.0\r\n') +
       e('content-type: text/${text != null ? 'plain' : 'html'}; charset=utf-8\r\n') +

--- a/test/messages/message_simple_utf8.dart
+++ b/test/messages/message_simple_utf8.dart
@@ -1,5 +1,6 @@
 part of message_out_test;
 
+final _dateHeader = 'date: Thu, 31 Mar 2022 00:00:00 \\+0000\r\n';
 
 final messageSimpleUtf8 = MessageTest(
     'Message with utf8 subject, html and text',
@@ -8,6 +9,8 @@ final messageSimpleUtf8 = MessageTest(
       ..recipients = ['test2@test.com']
       ..subject = defaultSubject
       ..html = defaultHtml
-      ..text = defaultText,
-    mailRegExpTextAndHtml(defaultSubjectRegExpUtf8),
-    mailRegExpTextAndHtml(defaultSubjectRegExpNotUtf8));
+      ..text = defaultText
+      ..headers = {'date': DateTime.utc(2022, 3, 31)},
+    mailRegExpTextAndHtml(defaultSubjectRegExpUtf8, dateHeader: _dateHeader),
+    mailRegExpTextAndHtml(defaultSubjectRegExpNotUtf8,
+        dateHeader: _dateHeader));


### PR DESCRIPTION
SMTP headers with dates should always use the en_US locale.

fixes #201