### PR TITLE
fix non-ascii attachment name

### DIFF
--- a/lib/src/smtp/internal_representation/ir_content.dart
+++ b/lib/src/smtp/internal_representation/ir_content.dart
@@ -160,10 +160,10 @@ class _IRContentAttachment extends _IRContent {
       _header.add(_IRHeaderText('content-id', _attachment.cid!));
     }
 
-    var fnSuffix = '';
-    if ((filename ?? '').isNotEmpty) fnSuffix = '; filename="$filename"';
-    _header.add(_IRHeaderText('content-disposition',
-        '${_describeEnum(_attachment.location)}$fnSuffix'));
+    final parms = <String, String>{};
+    if ((filename ?? '').isNotEmpty) parms['filename'] = filename!;
+    _header.add(_IRHeaderText(
+        'content-disposition', _describeEnum(_attachment.location), parms));
   }
 
   @override

--- a/lib/src/smtp/internal_representation/ir_header.dart
+++ b/lib/src/smtp/internal_representation/ir_header.dart
@@ -30,6 +30,30 @@ abstract class _IRHeader extends _IROutput {
     yield _$eol;
   }
 
+  Stream<List<int>> _outValueWithParms(
+      String value, _IRMetaInformation irMetaInformation,
+      [Map<String, String>? parms]) async* {
+    yield convert.utf8.encode(_name);
+    yield _$colonSpace;
+    if (_IRHeader._shallB64(value, irMetaInformation)) {
+      yield* _outB64(value);
+    } else {
+      yield convert.utf8.encode(value);
+    }
+    if (parms != null) {
+      for (var parm in (parms.entries)) {
+        yield convert.utf8.encode('; ${parm.key}="');
+        if (_IRHeader._shallB64(parm.value, irMetaInformation)) {
+          yield* _outB64(parm.value);
+        } else {
+          yield convert.utf8.encode(parm.value);
+        }
+        yield convert.utf8.encode('"');
+      }
+    }
+    yield _$eol;
+  }
+
   /// Outputs the given [addresses].
   Stream<List<int>> _outAddressesValue(Iterable<Address> addresses,
       _IRMetaInformation irMetaInformation) async* {
@@ -125,14 +149,13 @@ abstract class _IRHeader extends _IROutput {
 
 class _IRHeaderText extends _IRHeader {
   final String _value;
+  final Map<String, String>? _parms;
 
-  _IRHeaderText(String name, this._value) : super(name);
+  _IRHeaderText(String name, this._value, [this._parms]) : super(name);
 
   @override
   Stream<List<int>> out(_IRMetaInformation irMetaInformation) =>
-      _IRHeader._shallB64(_value, irMetaInformation)
-          ? _outValueB64(_value)
-          : _outValue(_value);
+      _outValueWithParms(_value, irMetaInformation, _parms);
 }
 
 class _IRHeaderAddress extends _IRHeader {


### PR DESCRIPTION
Fix the bug mentioned in issue #140. For attachments whose filename contains non-ascii characters, only `_value_` in `content-disposition: attachment; filename="_value_"` is expected to be encoded. For example, for an attachment named `测试.zip`, the Content-Disposition header should be
```
content-disposition: attachment; filename="=?utf-8?B?5rWL6K+VLnppcA==?="
```
 instead of 
```
content-disposition: =?utf-8?B?YXR0YWNobWVudDsgZmlsZW5hbWU9Iua1i+ivlS56aXAi?=
```
reference：[RFC2183#section-2](https://datatracker.ietf.org/doc/html/rfc2183#section-2)