### PR TITLE
Allow custom headers in attachments.

### DIFF
--- a/lib/src/entities/attachment.dart
+++ b/lib/src/entities/attachment.dart
@@ -30,6 +30,12 @@ abstract class Attachment {
   Location location = Location.attachment;
   String? fileName;
   late String contentType;
+
+  /// Additional headers that will be added to the attachment after all of the standard headers are set.
+  /// This is useful for adding, for example, "X-Attachment-Id" to an attachment, which is used by
+  /// gmail when referencing an image in `<img src="cid:...">`.
+  final Map<String, String> additionalHeaders = {};
+
   Stream<List<int>> asStream();
 }
 

--- a/lib/src/smtp/internal_representation/ir_content.dart
+++ b/lib/src/smtp/internal_representation/ir_content.dart
@@ -164,6 +164,12 @@ class _IRContentAttachment extends _IRContent {
     if ((filename ?? '').isNotEmpty) parms['filename'] = filename!;
     _header.add(_IRHeaderText(
         'content-disposition', _describeEnum(_attachment.location), parms));
+
+    // Add additional headers set by the user.
+    for (final headerEntry in _attachment.additionalHeaders.entries) {
+      _header
+          .add(_IRHeaderText(headerEntry.key.toLowerCase(), headerEntry.value));
+    }
   }
 
   @override

--- a/test/messages/message_all.dart
+++ b/test/messages/message_all.dart
@@ -22,6 +22,7 @@ final messageAll = () => MessageTest(
         StringAttachment('\u{1f596} \\o/' * 1000)..location = Location.inline,
         FileAttachment(File('test/exploits_of_a_mom.png')),
         StreamAttachment(countStream(1000).map(utf8.encode), 'application/json')
+          ..additionalHeaders['X-XYZ'] = 'XyZZy'
       ],
     mailRegExpTextHtmlAndInlineAttachments(_subjectBelow,
         [testStringAttachment], [testFileAttachment, testStreamAttachment],
@@ -331,4 +332,5 @@ final TestAttachment testStreamAttachment = TestAttachment(
         'ODE5ODA5ODE5ODI5ODE5ODI5ODM5ODI5ODM5ODQ5ODM5ODQ5ODU5ODQ5ODU5ODY5ODU5ODY5ODc5ODY5ODc5\r\n'
         'ODg5ODc5ODg5ODk5ODg5ODk5OTA5ODk5OTA5OTE5OTA5OTE5OTI5OTE5OTI5OTM5OTI5OTM5OTQ5OTM5OTQ5\r\n'
         'OTU5OTQ5OTU5OTY5OTU5OTY5OTc5OTY5OTc5OTg5OTc5OTg5OTk5OTg5OTkxMDAwOTk5MTAwMDEwMDExMDAw\r\n'
-        'MTAwMTEwMDJdfQ==');
+        'MTAwMTEwMDJdfQ==',
+    customHeader: 'x-xyz: XyZZy');

--- a/test/messages/message_helpers.dart
+++ b/test/messages/message_helpers.dart
@@ -65,8 +65,10 @@ class TestAttachment {
   final String type;
   final String disposition;
   final String content;
+  final String? customHeader;
 
-  TestAttachment(this.name, this.type, this.disposition, this.content);
+  TestAttachment(this.name, this.type, this.disposition, this.content,
+      {this.customHeader});
 }
 
 String mailRegExpTextHtmlAndInlineAttachments(String subject,
@@ -104,6 +106,7 @@ String mailRegExpTextHtmlAndInlineAttachments(String subject,
         e('content-type: ${a.type}\r\n') +
         e('content-transfer-encoding: base64\r\n') +
         e('content-disposition: ${a.disposition}\r\n') +
+        e(a.customHeader == null ? '' : '${a.customHeader}\r\n') +
         e('\r\n') +
         e('${a.name}\r\n') +
         e('\r\n');
@@ -115,6 +118,7 @@ String mailRegExpTextHtmlAndInlineAttachments(String subject,
         e('content-type: ${a.type}\r\n') +
         e('content-transfer-encoding: base64\r\n') +
         e('content-disposition: ${a.disposition}\r\n') +
+        e(a.customHeader == null ? '' : '${a.customHeader}\r\n') +
         e('\r\n') +
         e('${a.name}\r\n') +
         e('\r\n');


### PR DESCRIPTION
This change allows custom headers in attachments. This is useful for adding, for example, "X-Attachment-Id" to an attachment, which is used by gmail when referencing an image in `<img src="cid:...">`.