### PR TITLE
Fix yahoo SmtpServer definition regarding ssl

### DIFF
--- a/lib/smtp_server/yahoo.dart
+++ b/lib/smtp_server/yahoo.dart
@@ -2,4 +2,4 @@ import '../smtp_server.dart';
 
 SmtpServer yahoo(String username, String password) =>
     SmtpServer('smtp.mail.yahoo.com',
-        port: 465, username: username, password: password);
+        port: 465, username: username, password: password, ssl: true);


### PR DESCRIPTION
The current definition of the yahoo SmtpServer uses port 465 which however is used for SSL connections (as described [here](https://help.yahoo.com/kb/SLN4724.html)).
In the previous definition, the ssl parameter was set to false. This PR adds ```ssl: true``` to the parameter list of the yahoo SmtpServers constructor invocation.

This could be the solution to issue #229. 