### PR TITLE
feat: allow `intl 0.19.0` bump version to 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.1.0
+* Add auth plain  
+  Thansk https://github.com/michep
+* Allow `intl 0.19.0` as dependency
+
 ## 6.0.1
 * Fix yahoo definition  
   Thanks https://github.com/schneiti 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 6.0.1
+version: 6.1.0
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails
@@ -9,7 +9,7 @@ environment:
 dependencies:
   async: '^2.5.0'
   logging: '^1.0.0'
-  intl: '>=0.17.0 <0.19.0'
+  intl: '>=0.17.0 <0.20.0'
   mime: '^1.0.0'
   path: '^1.7.0'
   meta: '^1.3.0'


### PR DESCRIPTION
This version now includes the auth plain (merged via PR).