### PR TITLE
fix: return correct return code if recipient mail address is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 6.1.2
+* Fix error code if recipients mail address is empty.  
+  Thanks https://github.com/amugofjava
+
 ## 6.1.1
-* Close connections in finally block
+* Close connections in finally block  
   Thanks https://github.com/darkstarx
 
 ## 6.1.0

--- a/lib/src/smtp/validator.dart
+++ b/lib/src/smtp/validator.dart
@@ -64,7 +64,7 @@ List<Problem> validate(Message message) {
 
     validate(
         a != null && (a.mailAddress).isNotEmpty,
-        'FROM_ADDRESS_EMPTY',
+        'TO_ADDRESS_EMPTY',
         'A recipient address is null or empty.  (pos: $counter).');
     if (a != null) {
       validate(_validAddress(a), 'FROM_ADDRESS',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 6.1.1
+version: 6.1.2
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails


### PR DESCRIPTION
fixes #255

This was obviously the wrong code, which makes me confident enough, that we can push this as bug-fix instead of a major release.