### PR TITLE
fix: use range for intl library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.4.1
+* Fix dependency range for intl library.  
+  Thanks https://github.com/isoos and https://github.com/mnordine
+
 ## 6.4.0
 * Switch to `^0.17` instead of range for the intl dependency.  
   Thanks https://github.com/mnordine

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 6.4.0
+version: 6.4.1
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails
@@ -9,7 +9,7 @@ environment:
 dependencies:
   async: '^2.5.0'
   logging: '^1.0.0'
-  intl: '^0.17.0'
+  intl: '>=0.17.0 <1.0.0'
   mime: '>=1.0.0 <3.0.0'
   path: '^1.7.0'
   meta: '^1.3.0'


### PR DESCRIPTION
Versions below 1 behave differently when using `^0.xx.yy`.

We need to specify the range if we want to allow all versions below 1.

This is risky, as libraries are allowed to change the API.