### PR TITLE
Upgrade punycoder to v0.3.0 and refactor IDNA/Address handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.2.0
+* Upgrade `punycoder` to v0.3.0.
+* Refactor IDNA module to use `domainToAscii` and `domainToUnicode` from `punycoder`.
+* Refactor `Address.encodedAddress` to use `emailToAscii` from `punycoder`.
+* Maintain `IdnaException` for backward compatibility by wrapping `punycoder`'s `FormatException`.
+
 ## 7.1.0
 * allow mime 2.0.0 and intl up to 0.21.0
   Thanks https://github.com/karelklic

--- a/lib/src/core/address.dart
+++ b/lib/src/core/address.dart
@@ -1,4 +1,5 @@
-import '../idna/idna.dart';
+import 'package:punycoder/punycoder.dart';
+import 'package:unorm_dart/unorm_dart.dart' as unorm;
 
 final _quotableNameRegExp = RegExp(r'[",]');
 
@@ -26,21 +27,19 @@ class Address {
   ///
   /// This properly handles internationalized domain names by:
   /// 1. Normalizing Unicode to NFC
-  /// 2. Converting to lowercase
-  /// 3. Encoding non-ASCII labels with Punycode (xn-- prefix)
+  /// 2. Converting the domain to Punycode using [emailToAscii]
   ///
-  /// The local-part (before @) is not modified, as SMTP does not support
-  /// UTF-8 in local-parts without the SMTPUTF8 extension.
+  /// The local-part (before @) is not modified by [emailToAscii].
   String get encodedAddress {
     try {
-      final lastAt = mailAddress.lastIndexOf('@');
-      if (lastAt == -1) {
+      if (!mailAddress.contains('@')) {
         return mailAddress;
       }
-      final localPart = mailAddress.substring(0, lastAt);
-      final domain = mailAddress.substring(lastAt + 1);
-      final encodedDomain = idnaEncode(domain);
-      return '$localPart@$encodedDomain';
+
+      // Normalize to NFC before encoding
+      final normalized = unorm.nfc(mailAddress);
+
+      return emailToAscii(normalized);
     } catch (_) {
       return mailAddress;
     }

--- a/lib/src/idna/idna.dart
+++ b/lib/src/idna/idna.dart
@@ -22,13 +22,25 @@ const int maxDomainLength = 253;
 /// The ACE (ASCII Compatible Encoding) prefix for Punycode labels.
 const String acePrefix = 'xn--';
 
+/// Exception thrown when IDNA encoding fails.
+class IdnaException implements Exception {
+  /// A description of the error.
+  final String message;
+
+  /// Creates an [IdnaException] with the given [message].
+  const IdnaException(this.message);
+
+  @override
+  String toString() => 'IdnaException: $message';
+}
+
 /// Encodes a domain name to its ASCII-compatible (Punycode) form.
 ///
 /// This function:
 /// 1. Normalizes the domain to NFC
 /// 2. Applies IDNA encoding using [domainToAscii]
 ///
-/// Throws [FormatException] if encoding or validation fails.
+/// Throws [IdnaException] if encoding or validation fails.
 ///
 /// Example:
 /// ```dart
@@ -45,15 +57,19 @@ String idnaEncode(String domain) {
   // punycoder expects input to be normalized.
   final normalized = unorm.nfc(domain);
 
-  // Use domainToAscii which handles splitting, lowercase, prefix and validation
-  return domainToAscii(normalized);
+  try {
+    // Use domainToAscii which handles splitting, lowercase, prefix and validation
+    return domainToAscii(normalized);
+  } on FormatException catch (e) {
+    throw IdnaException(e.message);
+  }
 }
 
 /// Decodes a Punycode-encoded domain name back to Unicode.
 ///
 /// This function uses [domainToUnicode] to handle 'xn--' prefixed labels.
 ///
-/// Throws [FormatException] if Punycode decoding fails.
+/// Throws [IdnaException] if Punycode decoding fails.
 ///
 /// Example:
 /// ```dart
@@ -64,7 +80,11 @@ String idnaDecode(String domain) {
     return domain;
   }
 
-  return domainToUnicode(domain);
+  try {
+    return domainToUnicode(domain);
+  } on FormatException catch (e) {
+    throw IdnaException(e.message);
+  }
 }
 
 /// Checks if a domain contains any non-ASCII characters.

--- a/lib/src/idna/idna.dart
+++ b/lib/src/idna/idna.dart
@@ -22,35 +22,13 @@ const int maxDomainLength = 253;
 /// The ACE (ASCII Compatible Encoding) prefix for Punycode labels.
 const String acePrefix = 'xn--';
 
-/// Exception thrown when IDNA encoding fails.
-class IdnaException implements Exception {
-  /// A description of the error.
-  final String message;
-
-  /// Creates an [IdnaException] with the given [message].
-  const IdnaException(this.message);
-
-  @override
-  String toString() => 'IdnaException: $message';
-}
-
-/// The Punycode codec instance used for encoding/decoding.
-const _punycodeCodec = PunycodeCodec();
-
 /// Encodes a domain name to its ASCII-compatible (Punycode) form.
 ///
 /// This function:
-/// 1. Splits the domain into labels (parts between dots)
-/// 2. Normalizes each label to NFC (Normalization Form Canonical Composition)
-/// 3. Performs case folding (converts to lowercase)
-/// 4. Applies Punycode encoding with 'xn--' prefix for non-ASCII labels
-/// 5. Validates label lengths (≤63 characters)
+/// 1. Normalizes the domain to NFC
+/// 2. Applies IDNA encoding using [domainToAscii]
 ///
-/// Throws [IdnaException] if:
-/// - A label exceeds 63 characters after encoding
-/// - The domain exceeds 253 characters
-/// - A label is empty
-/// - The Punycode encoding fails
+/// Throws [FormatException] if encoding or validation fails.
 ///
 /// Example:
 /// ```dart
@@ -63,70 +41,19 @@ String idnaEncode(String domain) {
     return domain;
   }
 
-  final labels = domain.split('.');
-  final encodedLabels = <String>[];
+  // Normalize to NFC (Normalization Form Canonical Composition)
+  // punycoder expects input to be normalized.
+  final normalized = unorm.nfc(domain);
 
-  for (final label in labels) {
-    final encoded = _encodeLabel(label);
-    encodedLabels.add(encoded);
-  }
-
-  final result = encodedLabels.join('.');
-
-  // Validate total domain length
-  if (result.length > maxDomainLength) {
-    throw IdnaException('Encoded domain exceeds maximum length of $maxDomainLength characters: '
-        '${result.length} characters');
-  }
-
-  return result;
-}
-
-/// Encodes a single domain label using IDNA rules.
-String _encodeLabel(String label) {
-  if (label.isEmpty) {
-    // Empty labels can occur with trailing dots (e.g., "example.com.")
-    // Return as-is to preserve the structure
-    return label;
-  }
-
-  // 1. Normalize to NFC (Normalization Form Canonical Composition)
-  // This ensures that characters like 'ü' (U+00FC) and 'u' + '̈' (U+0308)
-  // are treated identically.
-  String normalized = unorm.nfc(label);
-
-  // 2. Case folding: convert to lowercase
-  // Domain names are case-insensitive per DNS specifications.
-  normalized = normalized.toLowerCase();
-
-  // 3. Encode using PunycodeCodec
-  // The codec automatically:
-  // - Returns unchanged if already ASCII
-  // - Adds 'xn--' prefix for non-ASCII labels
-  try {
-    final encoded = _punycodeCodec.encode(normalized);
-
-    // 4. Validate encoded label length
-    if (encoded.length > maxLabelLength) {
-      throw IdnaException('Encoded label exceeds maximum length of $maxLabelLength characters: '
-          '"$encoded" (${encoded.length} characters)');
-    }
-
-    return encoded;
-  } catch (e) {
-    if (e is IdnaException) rethrow;
-    throw IdnaException('Failed to encode label "$label": $e');
-  }
+  // Use domainToAscii which handles splitting, lowercase, prefix and validation
+  return domainToAscii(normalized);
 }
 
 /// Decodes a Punycode-encoded domain name back to Unicode.
 ///
-/// This function:
-/// 1. Splits the domain into labels
-/// 2. Detects 'xn--' prefixed labels and decodes them
-/// 3. Returns the decoded Unicode domain
+/// This function uses [domainToUnicode] to handle 'xn--' prefixed labels.
 ///
-/// Throws [IdnaException] if Punycode decoding fails.
+/// Throws [FormatException] if Punycode decoding fails.
 ///
 /// Example:
 /// ```dart
@@ -137,29 +64,7 @@ String idnaDecode(String domain) {
     return domain;
   }
 
-  final labels = domain.split('.');
-  final decodedLabels = <String>[];
-
-  for (final label in labels) {
-    final decoded = _decodeLabel(label);
-    decodedLabels.add(decoded);
-  }
-
-  return decodedLabels.join('.');
-}
-
-/// Decodes a single Punycode label.
-String _decodeLabel(String label) {
-  if (label.isEmpty) {
-    return label;
-  }
-
-  // PunycodeCodec.decode handles 'xn--' prefixed labels automatically
-  try {
-    return _punycodeCodec.decode(label);
-  } catch (e) {
-    throw IdnaException('Failed to decode Punycode label "$label": $e');
-  }
+  return domainToUnicode(domain);
 }
 
 /// Checks if a domain contains any non-ASCII characters.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   mime: '>=1.0.5 <3.0.0'
   path: '^1.8.3'
   meta: '^1.11.0'
-  punycoder: '^0.2.2'
+  punycoder: '^0.3.0'
   unorm_dart: '^0.3.2'
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mailer
-version: 7.1.0
+version: 7.2.0
 description: >
   Compose and send emails from Dart.
   Supports file attachments and HTML emails.

--- a/test/idna_test.dart
+++ b/test/idna_test.dart
@@ -88,7 +88,7 @@ void main() {
     group('Error handling', () {
       test('throws on label exceeding max length', () {
         final longLabel = 'a' * 64;
-        expect(() => idnaEncode('$longLabel.com'), throwsA(isA<FormatException>()));
+        expect(() => idnaEncode('$longLabel.com'), throwsA(isA<IdnaException>()));
       });
     });
   });

--- a/test/idna_test.dart
+++ b/test/idna_test.dart
@@ -88,7 +88,7 @@ void main() {
     group('Error handling', () {
       test('throws on label exceeding max length', () {
         final longLabel = 'a' * 64;
-        expect(() => idnaEncode('$longLabel.com'), throwsA(isA<IdnaException>()));
+        expect(() => idnaEncode('$longLabel.com'), throwsA(isA<FormatException>()));
       });
     });
   });


### PR DESCRIPTION
Hi there! 👋

I'm the author of the `punycoder` package that you're using. I just did a major rewrite that I published today and the API had changed somewhat ([CHANGELOG](https://github.com/dropbear-software/punycoder/blob/main/CHANGELOG.md)) and in the spirit of trying to make life easy for you I went ahead and migrated your package over.


## Details
This PR upgrades the `punycoder` dependency from v0.2.x to v0.3.0 and refactors the package's IDNA and email address encoding logic to align with the new API.

  ### Key Changes:
   * Dependency Upgrade: Bumped `punycoder` to v0.3.0 in `pubspec.yaml`.
   * IDNA Refactor: Updated `lib/src/idna/idna.dart` to use the new `domainToAscii` and `domainToUnicode` top-level functions. This simplifies the module by delegating RFC-compliant label splitting, prefix management, and validation to the library.
   * Address Refactor: Updated `Address.encodedAddress` in `lib/src/core/address.dart` to use the new `emailToAscii` helper.
   * Backward Compatibility:
       * Maintained the `IdnaException` class by wrapping punycoder's `FormatException`. This ensures that any existing error handling in consumer code remains functional.
       * Explicitly preserved NFC Unicode normalization (using `unorm_dart`) before passing data to `punycoder`, as the new version expects pre-normalized input.
   * Version Bump: Updated package version to 7.2.0 and updated `CHANGELOG.md`.


  ### Verification:
   * Ran the full test suite (test/test.dart), and all 158 tests passed successfully, including specific edge cases for multi-label domains, internationalized email addresses, and UTF-8 normalization.
   * Verified that the refactor maintains correct behavior for domains with already-encoded Punycode labels and addresses with multiple @ symbols.